### PR TITLE
Revert previous spec changes

### DIFF
--- a/libfabric.spec
+++ b/libfabric.spec
@@ -1,36 +1,29 @@
-%define suse_libname libfabric1
-
 Name: libfabric
 Version: 1.8.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: User-space RDMA Fabric Interfaces
-%if 0%{?suse_version} >= 1315
-License: GPL-2.0-only OR BSD-2-Clause
-Group: Development/Libraries/C and C++
-%else
 Group: System Environment/Libraries
 License: GPLv2 or BSD
-%endif
 Url: https://www.github.com/ofiwg/libfabric
 Source: https://github.com/ofiwg/%{name}/archive/v%{version}.tar.gz
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel
+BuildRequires: libibverbs-devel >= 1.2.0
+BuildRequires: libnl3-devel
+# needed for psm2_am_register_handlers_2@PSM2_1.0
+BuildRequires: libpsm2-devel >= 10.3.58
 %else
 %if 0%{?suse_version} >= 1315
 BuildRequires: rdma-core-devel
 %endif
 %endif
-BuildRequires: libibverbs-devel >= 1.2.0
-BuildRequires: libnl3-devel
-BuildRequires: fdupes
 
 # infinipath-psm-devel only available for x86_64
 %ifarch x86_64
-# needed for psm2_am_register_handlers_2@PSM2_1.0
 BuildRequires: infinipath-psm-devel
 %if 0%{?suse_version} >= 1315 || 0%{?rhel} >= 7
-BuildRequires: libpsm2-devel >= 10.3.58
+BuildRequires: libpsm2-devel
 %endif
 %endif
 # valgrind is unavailable for s390
@@ -42,7 +35,7 @@ BuildRequires: valgrind-devel
 BuildRequires: autoconf, automake, libtool
 
 %ifarch x86_64
-%if 0%{?suse_version} >= 01315 || 0%{?rhel} >= 7
+%if 0%{?suse_version} > 01315 || 0%{?rhel} >= 7
 %global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --enable-psm --enable-psm2
 %else
 %global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static
@@ -55,25 +48,10 @@ BuildRequires: autoconf, automake, libtool
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA.
 
-%if 0%{?suse_version} >= 01315
-%package -n %{suse_libname}
-Summary: Shared library for libfabric
-Group:  System/Libraries
-
-%description -n %{suse_libname}
-libfabric provides a user-space API to access high-performance fabric
-services, such as RDMA. This package contains the runtime library.
-%endif
-
 %package devel
 Summary: Development files for the libfabric library
-%if 0%{?suse_version} >= 01315
-Group: Development/Libraries/C and C++
-Requires: %{suse_libname}%{?_isa} = %{version}-%{release}
-%else
 Group: System Environment/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
-%endif
 
 %description devel
 Development files for the libfabric library.
@@ -99,52 +77,40 @@ make %{?_smp_mflags} V=1
 %make_install
 # remove unpackaged files from the buildroot
 rm -f %{buildroot}%{_libdir}/*.la
-%fdupes %{buildroot}/%{_prefix}
 
-%if 0%{?suse_version} >= 01315
-%post -n %{suse_libname} -p /sbin/ldconfig
-%postun -n %{suse_libname} -p /sbin/ldconfig
-%else
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
-%endif
 
 %files
-%defattr(-,root,root,-)
-%if 0%{?rhel} >= 7
 %{_libdir}/libfabric.so.*
-%endif
 %{_bindir}/fi_info
 %{_bindir}/fi_pingpong
 %{_bindir}/fi_strerror
-%if 0%{?rhel} >= 7
 %{_libdir}/pkgconfig/%{name}.pc
-%endif
 %{_mandir}/man1/*
-%doc NEWS.md
-%license COPYING
-
-%if 0%{?suse_version} >= 01315
-%files -n %{suse_libname}
-%defattr(-,root,root)
-%{_libdir}/libfabric.so.*
 %license COPYING
 %doc AUTHORS README
-%endif
 
 %files devel
-%defattr(-,root,root)
 %{_libdir}/libfabric.so
-%{_libdir}/pkgconfig/%{name}.pc
 %{_includedir}/*
 %{_mandir}/man3/*
 %{_mandir}/man7/*
 
 %changelog
+* Thu Aug 22 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.8.0-3
+- Revert previous change as it was causing (on SLES 12.3):
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_epaddr_to_epid@PSM2_1.0'
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_disconnect2@PSM2_1.0'
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_am_register_handlers_2@PSM2_1.0'
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_info_query@PSM2_1.0'
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_get_capability_mask@PSM2_1.0'
+/usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_epid_lookup2@PSM2_1.0'
+
 * Tue Aug 20 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.8.0-2
-- install libnl3-devel on all platforms
-- create a libfabric1 subpackage with the shared library
-- clean up much of SUSE's post build linting errors/warnings
+- Install libnl3-devel on all platforms
+- Create a libfabric1 subpackage with the shared library
+- Clean up much of SUSE's post build linting errors/warnings
 
 * Thu Jul 25 2019 Alexander A. Oganeozv <alexnader.a.oganezov@intel.com> - 1.8.0-1
 - Update to 1.8.0

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -18,6 +18,9 @@ BuildRequires: libpsm2-devel >= 10.3.58
 BuildRequires: rdma-core-devel
 %endif
 %endif
+BuildRequires: libibverbs-devel >= 1.2.0
+BuildRequires: libnl3-devel
+BuildRequires: fdupes
 
 # infinipath-psm-devel only available for x86_64
 %ifarch x86_64
@@ -106,6 +109,7 @@ rm -f %{buildroot}%{_libdir}/*.la
 /usr/lib64/libfabric.so.1: undefined reference to `psm2_info_query@PSM2_1.0'
 /usr/lib64/libfabric.so.1: undefined reference to `psm2_get_capability_mask@PSM2_1.0'
 /usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_epid_lookup2@PSM2_1.0'
+- But still install libnl3-devel on all platforms
 
 * Tue Aug 20 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.8.0-2
 - Install libnl3-devel on all platforms

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -45,7 +45,7 @@ BuildRequires: autoconf, automake, libtool
 %if 0%{?suse_version} > 01315 || 0%{?rhel} >= 7
 %global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --enable-psm --enable-psm2
 %else
-%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static
+%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --disable-psm --disable-psm2
 %endif
 %else
 %global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static
@@ -152,6 +152,7 @@ rm -f %{buildroot}%{_libdir}/*.la
 /usr/lib64/libfabric.so.1: undefined reference to `psm2_get_capability_mask@PSM2_1.0'
 /usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_epid_lookup2@PSM2_1.0'
 - But still install libnl3-devel on all platforms
+- Explicitly disable psm and psm2 on SLES 12.3 due to the above
 
 * Tue Aug 20 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.8.0-2
 - Install libnl3-devel on all platforms


### PR DESCRIPTION
As it was causing:

/usr/lib64/libfabric.so.1: undefined reference to `psm2_epaddr_to_epid@PSM2_1.0'
/usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_disconnect2@PSM2_1.0'
/usr/lib64/libfabric.so.1: undefined reference to `psm2_am_register_handlers_2@PSM2_1.0'
/usr/lib64/libfabric.so.1: undefined reference to `psm2_info_query@PSM2_1.0'
/usr/lib64/libfabric.so.1: undefined reference to `psm2_get_capability_mask@PSM2_1.0'
/usr/lib64/libfabric.so.1: undefined reference to `psm2_ep_epid_lookup2@PSM2_1.0'

on SLES 12.3.