### PR TITLE
DAOS-4943 sockets: Add messages for connect errors

### DIFF
--- a/libfabric.spec
+++ b/libfabric.spec
@@ -2,7 +2,7 @@
 
 Name: libfabric
 Version: 1.9.0
-Release: 7%{?dist}
+Release: 8%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 %if 0%{?suse_version} >= 1315
 License: GPL-2.0-only OR BSD-2-Clause
@@ -143,6 +143,9 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Thu Aug 20 2020 Li Wei <wei.g.li@intel.com> - 1.9.0-8
+- Update sockets_provider.patch to report the original connect errors
+
 * Wed Jul 1 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 1.9.0-7
 - Commented out infinipath from BuildRequires
 - Removed --enable-psm from configuration flags

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -12,7 +12,7 @@ MAINTAINER daos-stack <daos@daos.groups.io>
 ARG UID=1000
 
 # Install basic tools
-RUN dnf -y install mock\ \<\ 2 mock-core-configs\ \<\ 32 make \
+RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
                    python-srpm-macros rpmdevtools
 

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -14,6 +14,7 @@ DISTRO_BASE = $(basename UBUNTU_$(VERSION_ID))
 VERSION_ID_STR := $(subst $(DOT),_,$(VERSION_ID))
 endif
 ifeq ($(ID),fedora)
+SPECTOOL    := spectool
 # a Fedora-based mock builder
 # derive the the values of:
 # VERSION_ID (i.e. 7)
@@ -27,9 +28,22 @@ DISTRO_ID   := el7
 DISTRO_BASE := EL_7
 SED_EXPR    := 1s/$(DIST)//p
 endif
+ifeq ($(CHROOT_NAME),epel-8-x86_64)
+DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID  := 8
+DISTRO_ID   := el8
+DISTRO_BASE := EL_8
+SED_EXPR    := 1s/$(DIST)//p
+endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.1-x86_64)
 VERSION_ID  := 15.1
 DISTRO_ID   := sl15.1
+DISTRO_BASE := LEAP_15
+SED_EXPR    := 1p
+endif
+ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
+VERSION_ID  := 15.2
+DISTRO_ID   := sl15.2
 DISTRO_BASE := LEAP_15
 SED_EXPR    := 1p
 endif
@@ -45,6 +59,7 @@ DISTRO_ID := el$(VERSION_ID)
 DISTRO_BASE := $(basename EL_$(VERSION_ID))
 DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 SED_EXPR    := 1s/$(DIST)//p
+SPECTOOL    := spectool
 define install_repo
 	if yum-config-manager --add-repo=$(1); then                  \
 	    repo_file=$$(ls -tar /etc/yum.repos.d/*.repo | tail -1); \
@@ -66,6 +81,7 @@ DISTRO_ID := sle$(VERSION_ID)
 DISTRO_BASE := $(basename SLES_$(VERSION_ID))
 endif
 ifeq ($(ID_LIKE),suse)
+SPECTOOL    := rpmdev-spectool
 define install_repo
 	zypper --non-interactive ar $(1)
 endef

--- a/sockets_provider.patch
+++ b/sockets_provider.patch
@@ -1,5 +1,5 @@
 diff --git a/prov/sockets/src/sock_av.c b/prov/sockets/src/sock_av.c
-index e33e3b8..05d3972 100644
+index e33e3b883..05d3972a1 100644
 --- a/prov/sockets/src/sock_av.c
 +++ b/prov/sockets/src/sock_av.c
 @@ -441,10 +441,12 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
@@ -16,7 +16,7 @@ index e33e3b8..05d3972 100644
  	return 0;
  }
 diff --git a/prov/sockets/src/sock_conn.c b/prov/sockets/src/sock_conn.c
-index 8c739db..da9489b 100644
+index 8c739db74..be080efe2 100644
 --- a/prov/sockets/src/sock_conn.c
 +++ b/prov/sockets/src/sock_conn.c
 @@ -167,8 +167,9 @@ void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn)
@@ -31,17 +31,72 @@ index 8c739db..da9489b 100644
  }
  
  static int sock_conn_get_next_index(struct sock_conn_map *map)
-@@ -581,6 +582,8 @@ retry:
+@@ -540,7 +541,11 @@ do_connect:
  
- 	SOCK_LOG_ERROR("Connect error, retrying - %s - %d\n",
- 		       strerror(ofi_sockerr()), conn_fd);
+ 			ret = poll(&poll_fd, 1, sock_conn_timeout);
+ 			if (ret < 0) {
+-				SOCK_LOG_DBG("poll failed\n");
++				SOCK_LOG_ERROR("poll failed: %s\n",
++					       strerror(ofi_sockerr()));
++				goto retry;
++			} else if (ret == 0) {
++				SOCK_LOG_ERROR("poll timed out\n");
+ 				goto retry;
+ 			}
+ 
+@@ -548,21 +553,22 @@ do_connect:
+ 			ret = getsockopt(conn_fd, SOL_SOCKET, SO_ERROR,
+ 					 (void*)(&valopt), &lon);
+ 			if (ret < 0) {
+-				SOCK_LOG_DBG("getsockopt failed: %d, %d\n",
+-					     ret, conn_fd);
++				SOCK_LOG_ERROR("getsockopt failed: %d, %d\n",
++					       ret, conn_fd);
+ 				goto retry;
+ 			}
+ 
+ 			if (valopt) {
+-				SOCK_LOG_DBG("Error in connection() "
+-					     "%d - %s - %d\n",
+-					     valopt, strerror(valopt), conn_fd);
++				SOCK_LOG_ERROR("Error in connection() "
++					       "%d - %s - %d\n",
++					       valopt, strerror(valopt),
++					       conn_fd);
+ 				goto retry;
+ 			}
+ 			goto out;
+ 		} else {
+-			SOCK_LOG_DBG("Timeout or error() - %s: %d\n",
+-				     strerror(ofi_sockerr()), conn_fd);
++			SOCK_LOG_ERROR("Timeout or error() - %s: %d\n",
++				       strerror(ofi_sockerr()), conn_fd);
+ 			goto retry;
+ 		}
+ 	} else {
+@@ -571,6 +577,11 @@ do_connect:
+ 
+ retry:
+ 	do_retry--;
 +	ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-+			"Retry connect to peer ", &addr.sa);
++			"Error connecting to ", &addr.sa);
++	SOCK_LOG_ERROR("Connect error%s - %s - %d\n",
++		       do_retry ? ", retrying" : "", strerror(ofi_sockerr()),
++		       conn_fd);
+ 	if (!do_retry)
+ 		goto err;
+ 
+@@ -579,8 +590,6 @@ retry:
+ 		conn_fd = -1;
+ 	}
+ 
+-	SOCK_LOG_ERROR("Connect error, retrying - %s - %d\n",
+-		       strerror(ofi_sockerr()), conn_fd);
          goto do_connect;
  
  out:
 diff --git a/prov/sockets/src/sock_ep.c b/prov/sockets/src/sock_ep.c
-index 2f1ff9a..18d8dfd 100644
+index 2f1ff9add..18d8dfdd1 100644
 --- a/prov/sockets/src/sock_ep.c
 +++ b/prov/sockets/src/sock_ep.c
 @@ -1786,6 +1786,8 @@ err1:
@@ -129,7 +184,7 @@ index 2f1ff9a..18d8dfd 100644
  	}
  
 diff --git a/prov/sockets/src/sock_progress.c b/prov/sockets/src/sock_progress.c
-index 151ee50..e4a0892 100644
+index 151ee503c..e4a0892f1 100644
 --- a/prov/sockets/src/sock_progress.c
 +++ b/prov/sockets/src/sock_progress.c
 @@ -1942,13 +1942,12 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,


### PR DESCRIPTION
Add error messages to sockets_provider.patch, so that libfabric will
report a more useful error when it fails to establish a connection.

Signed-off-by: Li Wei <wei.g.li@intel.com>