### PR TITLE
CART-954 ofi: Update ofi to 1.12.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ libfabric (1.12.0-1) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Update to 1.12.0
 
- -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Tue, 16 Feb 2021 13:54:52 -0400
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Wed, 10 Mar 2021 13:54:52 -0400
 
 libfabric (1.12.0~rc1-1) unstable; urgency=medium
   [ Alexander Oganezov ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfabric (1.12.0-1) unstable; urgency=medium
+  [ Alexander Oganezov ]
+  * Update to 1.12.0
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Tue, 16 Feb 2021 13:54:52 -0400
+
 libfabric (1.12.0~rc1-1) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Update to 1.12.0rc1

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,8 @@ configure_providers = \
 	--enable-rxm=yes \
 	--enable-rxd=yes \
 	--enable-bgq=no \
+	--enable-efa=no \
+	--without-gdrcopy \
 	$(NULL)
 
 %:

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -2,7 +2,6 @@
 %global major 1
 %global minor 12
 %global bugrelease 0
-%global prerelease rc1
 %global dl_version %{major}.%{minor}.%{bugrelease}%{?prerelease:%{prerelease}}
 
 Name: libfabric
@@ -47,12 +46,12 @@ BuildRequires: autoconf, automake, libtool
 
 %ifarch x86_64
 %if 0%{?suse_version} >= 01315 || 0%{?rhel} >= 7
-%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --enable-psm2 --disable-efa
+%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --enable-psm2 --disable-efa --without-gdrcopy
 %else
-%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --disable-efa
+%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --disable-efa --without-gdrcopy
 %endif
 %else
-%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static
+%global configopts --enable-sockets --enable-verbs --enable-usnic --disable-static --disable-efa --without-gdrcopy
 %endif
 
 %description
@@ -146,6 +145,9 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Wed Mar 10 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> - 1.12.0-1
+- Update to v1.12.0
+
 * Tue Feb 16 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> - 1.12.0~rc1-1
 - Update to v1.12.0rc1
 


### PR DESCRIPTION
- Update to OFI 1.12.0
- Disable gdrcopy/gdrapi linkage as this library is not required
for any of our operations

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>