### PR TITLE
DAOS-9173 ofi: revert fi_cancel patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfabric (1.14.0~rc3-3) unstable; urgency=medium
+  [ Johann Lombardi ]
+  * Revert fi_cancel patch from DAOS-9173
+
+ -- Johann Lombardi <johann.lombardi@intel.com>  Mon, 13 Dec 2021 09:00:00 -0000
+
 libfabric (1.14.0~rc3-2) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Apply OFI patch to fix DAOS-9173
@@ -158,7 +164,7 @@ libfabric (1.3.0-4) unstable; urgency=medium
 libfabric (1.3.0-3) unstable; urgency=medium
 
   * Update watch file. Upstream uses github only now.
-  * Install libfabric.pc. Thanks Marcin Ślusarz. (Closes: #826222)
+  * Install libfabric.pc. Thanks Marcin Slusarz. (Closes: #826222)
   * Point Vcs-* fields to HTTPS URLs
   * Enable hardening.
   * Add patch with a few typo fixes.

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -8,7 +8,7 @@
 
 Name: libfabric
 Version: %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 %if 0%{?suse_version} >= 1315
 License: GPL-2.0-only OR BSD-2-Clause
@@ -19,7 +19,6 @@ License: GPLv2 or BSD
 %endif
 Url: https://www.github.com/ofiwg/libfabric
 Source: https://github.com/ofiwg/%{name}/archive/v%{dl_version}.tar.gz
-Patch0: https://github.com/daos-stack/libfabric/daos-9173-ofi.patch
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel >= 1.0.16
@@ -148,6 +147,9 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Mon Dec 13 2021 Johann Lombardi <johann.lombardi@intel.com> - 1.14.0~rc3-3
+- Revert fi_cancel patch from DAOS-9173
+
 * Wed Dec 8 2021 Alexander Oganezov <alexander.a.oganezov@intel.com> - 1.14.0~rc3-2
 - Apply patch for DAOS-9173
 


### PR DESCRIPTION
Revert libfabric patch due to issues with soak.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>