### PR TITLE
DAOS-9376 libfabric: upgrade to 1.14.0 GA and apply PR 7365

### DIFF
--- a/daos-9376-ofi.patch
+++ b/daos-9376-ofi.patch
@@ -1,0 +1,145 @@
+diff --git a/prov/verbs/src/fi_verbs.h b/prov/verbs/src/fi_verbs.h
+index 3424236b6b..f770f59479 100644
+--- a/prov/verbs/src/fi_verbs.h
++++ b/prov/verbs/src/fi_verbs.h
+@@ -620,10 +620,10 @@ struct vrb_ep {
+ };
+ 
+ 
+-enum vrb_op_ctx {
+-	VRB_POST_SQ,
+-	VRB_POST_RQ,
+-	VRB_POST_SRQ,
++enum vrb_op_queue {
++	VRB_OP_SQ,
++	VRB_OP_RQ,
++	VRB_OP_SRQ,
+ };
+ 
+ struct vrb_context {
+@@ -633,9 +633,12 @@ struct vrb_context {
+ 		struct vrb_srq_ep	*srx;
+ 	};
+ 	void				*user_ctx;
+-	enum vrb_op_ctx			op_ctx;
++	enum vrb_op_queue		op_queue;
++	enum ibv_wr_opcode		sq_opcode;
+ };
+ 
++enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr);
++
+ #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
+ struct vrb_xrc_ep {
+ 	/* Must be first */
+diff --git a/prov/verbs/src/verbs_cq.c b/prov/verbs/src/verbs_cq.c
+index 49be93c730..276f932c05 100644
+--- a/prov/verbs/src/verbs_cq.c
++++ b/prov/verbs/src/verbs_cq.c
+@@ -37,6 +37,22 @@
+ 
+ #include "fi_verbs.h"
+ 
++
++enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr)
++{
++	static enum ibv_wc_opcode wc[] = {
++		[IBV_WR_RDMA_WRITE] = IBV_WC_RDMA_WRITE,
++		[IBV_WR_RDMA_WRITE_WITH_IMM] = IBV_WC_RDMA_WRITE,
++		[IBV_WR_SEND] = IBV_WC_SEND,
++		[IBV_WR_SEND_WITH_IMM] = IBV_WC_SEND,
++		[IBV_WR_RDMA_READ] = IBV_WC_RDMA_READ,
++		[IBV_WR_ATOMIC_CMP_AND_SWP] = IBV_WC_COMP_SWAP,
++		[IBV_WR_ATOMIC_FETCH_AND_ADD] = IBV_WC_FETCH_ADD,
++	};
++
++	return (wr < ARRAY_SIZE(wc)) ? wc[wr] : IBV_WC_SEND;
++}
++
+ static void vrb_cq_read_context_entry(struct ibv_wc *wc, void *buf)
+ {
+ 	struct fi_cq_entry *entry = buf;
+@@ -239,7 +255,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
+ 
+ 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
+ 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+-		if (ctx->op_ctx == VRB_POST_SQ) {
++		if (ctx->op_queue == VRB_OP_SQ) {
+ 			assert(ctx->ep);
+ 			assert(!slist_empty(&ctx->ep->sq_list));
+ 			assert(ctx->ep->sq_list.head == &ctx->entry);
+@@ -248,13 +264,11 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
+ 			ctx->ep->sq_credits++;
+ 		}
+ 
+-		if (wc->status) {
+-			if (ctx->op_ctx == VRB_POST_SQ)
+-				wc->opcode &= ~IBV_WC_RECV;
+-			else
+-				wc->opcode |= IBV_WC_RECV;
+-		}
+-		if (ctx->op_ctx == VRB_POST_SRQ) {
++		/* workaround incorrect opcode reported by verbs */
++		wc->opcode = (ctx->op_queue == VRB_OP_SQ) ?
++			     vrb_wr2wc_opcode(ctx->sq_opcode) : IBV_WC_RECV;
++
++		if (ctx->op_queue == VRB_OP_SRQ) {
+ 			ofi_mutex_lock(&ctx->srx->ctx_lock);
+ 			ofi_buf_free(ctx);
+ 			ofi_mutex_unlock(&ctx->srx->ctx_lock);
+diff --git a/prov/verbs/src/verbs_ep.c b/prov/verbs/src/verbs_ep.c
+index c11e990610..632ad799be 100644
+--- a/prov/verbs/src/verbs_ep.c
++++ b/prov/verbs/src/verbs_ep.c
+@@ -71,7 +71,7 @@ ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr)
+ 
+ 	OFI_DBG_SET(ctx->ep, ep);
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_RQ;
++	ctx->op_queue = VRB_OP_RQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_recv(ep->ibv_qp, wr, &bad_wr);
+@@ -143,7 +143,8 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
+ 
+ 	ctx->ep = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_SQ;
++	ctx->op_queue = VRB_OP_SQ;
++	ctx->sq_opcode = wr->opcode;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_send(ep->ibv_qp, wr, &bad_wr);
+@@ -407,10 +408,7 @@ vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
+ 	return NULL;
+ }
+ 
+-/* Generate flush completion entries for any queued send requests.
+- * We only need to record the wr_id and that the entry was not a
+- * receive (indicated by lack of IBV_WC_RECV flag).
+- */
++/* Generate flush completion entries for any queued send requests. */
+ static void vrb_flush_sq(struct vrb_ep *ep)
+ {
+ 	struct vrb_context *ctx;
+@@ -429,9 +427,11 @@ static void vrb_flush_sq(struct vrb_ep *ep)
+ 	while (!slist_empty(&ep->sq_list)) {
+ 		entry = slist_remove_head(&ep->sq_list);
+ 		ctx = container_of(entry, struct vrb_context, entry);
+-		assert(ctx->op_ctx == VRB_POST_SQ);
++		assert(ctx->op_queue == VRB_OP_SQ);
+ 
+ 		wc.wr_id = (uintptr_t) ctx->user_ctx;
++		wc.opcode = vrb_wr2wc_opcode(ctx->sq_opcode);
++
+ 		cq->credits++;
+ 		ctx->ep->sq_credits++;
+ 		ofi_buf_free(ctx);
+@@ -1503,7 +1503,7 @@ ssize_t vrb_post_srq(struct vrb_srq_ep *ep, struct ibv_recv_wr *wr)
+ 
+ 	ctx->srx = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_SRQ;
++	ctx->op_queue = VRB_OP_SRQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_srq_recv(ep->srq, wr, &bad_wr);

--- a/daos-9376-ofi.patch
+++ b/daos-9376-ofi.patch
@@ -83,9 +83,9 @@ index 49be93c730..276f932c05 100644
 +			     vrb_wr2wc_opcode(ctx->sq_opcode) : IBV_WC_RECV;
 +
 +		if (ctx->op_queue == VRB_OP_SRQ) {
- 			ofi_mutex_lock(&ctx->srx->ctx_lock);
+ 			fastlock_acquire(&ctx->srx->ctx_lock);
  			ofi_buf_free(ctx);
- 			ofi_mutex_unlock(&ctx->srx->ctx_lock);
+ 			fastlock_release(&ctx->srx->ctx_lock);
 diff --git a/prov/verbs/src/verbs_ep.c b/prov/verbs/src/verbs_ep.c
 index c11e990610..632ad799be 100644
 --- a/prov/verbs/src/verbs_ep.c

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libfabric (1.14.0-1) unstable; urgency=medium
+  [ Johann Lombardi ]
+  * Upgrade to 1.14.0 GA
+  * Apply patch for DAOS-9376
+
+ -- Johann Lombardi <johann.lombardi@intel.com>  Mon, 17 Jan 2022 09:00:00 -0400
+
 libfabric (1.14.0~rc3-2) unstable; urgency=medium
   [ Alexander Oganezov ]
   * Apply OFI patch to fix DAOS-9173

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -2,13 +2,12 @@
 %global major 1
 %global minor 14
 %global bugrelease 0
-%global prerelease rc3
 
 %global dl_version %{major}.%{minor}.%{bugrelease}%{?prerelease:%{prerelease}}
 
 Name: libfabric
 Version: %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
-Release: 3%{?dist}
+Release: 1%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 %if 0%{?suse_version} >= 1315
 License: GPL-2.0-only OR BSD-2-Clause
@@ -20,6 +19,7 @@ License: GPLv2 or BSD
 Url: https://www.github.com/ofiwg/libfabric
 Source: https://github.com/ofiwg/%{name}/archive/v%{dl_version}.tar.gz
 Patch0: https://github.com/daos-stack/libfabric/daos-9173-ofi.patch
+Patch1: https://github.com/daos-stack/libfabric/daos-9376-ofi.patch
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel >= 1.0.16
@@ -154,6 +154,10 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Mon Jan 17 2022 Johann Lombardi <johann.lombardi@intel.com> - 1.14.0-1
+- Upgrade to 1.14.0 GA
+- Apply patch for DAOS-9376
+
 * Fri Dec 17 2021 Phillip Henderson <phillip.henderson@intel.com> - 1.14.0~rc3-3
 - Enable building debuginfo package on SUSE platforms
 


### PR DESCRIPTION
Upgrade from rc3 to official 1.14.0 libfabric version.
Apply workaround from libfabric PR #7365 to store ibv_wr_opcode
to use in error cases in the verbs provider to work around
DAOS-9376.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>