### PR TITLE
DAOS-9883 libfabric: Apply two patches for libfabric

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libfabric (1.14.0-2) unstable; urgency=medium
+  [ Dmitry Eremin ]
+  * Apply patch for TCP provider
+  * Revert patch with performance degradation
+
+ -- Dmitry Eremin <dmitry.eremin@intel.com>  Mon, 04 Apr 2022 09:00:00 -0400
+
 libfabric (1.14.0-1) unstable; urgency=medium
   [ Johann Lombardi ]
   * Upgrade to 1.14.0 GA

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -7,7 +7,7 @@
 
 Name: libfabric
 Version: %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 %if 0%{?suse_version} >= 1315
 License: GPL-2.0-only OR BSD-2-Clause
@@ -20,6 +20,8 @@ Url: https://www.github.com/ofiwg/libfabric
 Source: https://github.com/ofiwg/%{name}/archive/v%{dl_version}.tar.gz
 Patch0: https://github.com/daos-stack/libfabric/daos-9173-ofi.patch
 Patch1: https://github.com/daos-stack/libfabric/daos-9376-ofi.patch
+Patch2: https://github.com/daos-stack/libfabric/tcp_provider.patch
+Patch3: https://github.com/daos-stack/libfabric/revert.patch
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel >= 1.0.16
@@ -154,6 +156,10 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Mon Apr 04 2022 Dmitry Eremin <dmitry.eremin@intel.com> - 1.14.0-2
+- Apply patch for TCP provider
+- Revert patch with performance degradation
+
 * Mon Jan 17 2022 Johann Lombardi <johann.lombardi@intel.com> - 1.14.0-1
 - Upgrade to 1.14.0 GA
 - Apply patch for DAOS-9376

--- a/revert.patch
+++ b/revert.patch
@@ -1,0 +1,313 @@
+commit d8f2b3db73c8556949681f319d6dde7f0fc30cc0
+Author: Dmitry Eremin <dmitry.eremin@intel.com>
+Date:   Sat Apr 2 13:37:50 2022 +0300
+
+    Revert "core/pollfds: Use direct indexing instead of searches"
+    
+    This reverts commit 7ec82992a7c9a4c989e55d8d9a23aa43219e80f3.
+
+diff --git a/include/ofi_epoll.h b/include/ofi_epoll.h
+index de50d847004d..dad5844a91ee 100644
+--- a/include/ofi_epoll.h
++++ b/include/ofi_epoll.h
+@@ -82,7 +82,6 @@ struct ofi_pollfds {
+ };
+ 
+ int ofi_pollfds_create(struct ofi_pollfds **pfds);
+-int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
+ int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
+ 		    void *context);
+ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+@@ -93,14 +92,6 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
+ 		     int maxevents, int timeout);
+ void ofi_pollfds_close(struct ofi_pollfds *pfds);
+ 
+-/* OS specific */
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item);
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context);
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item);
+-
+ 
+ #ifdef HAVE_EPOLL
+ #include <sys/epoll.h>
+diff --git a/src/common.c b/src/common.c
+index 6206b8825e38..57283e8c7bdd 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -1306,38 +1306,6 @@ uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
+ }
+ #endif
+ 
+-int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size)
+-{
+-	struct pollfd *fds;
+-	void *contexts;
+-	size_t size;
+-
+-	if (max_size < pfds->size)
+-		return FI_SUCCESS;
+-
+-	size = max_size + 1;
+-	if (size < pfds->size + 64)
+-		size = pfds->size + 64;
+-
+-	fds = calloc(size, sizeof(*pfds->fds) + sizeof(*pfds->context));
+-	if (!fds)
+-		return -FI_ENOMEM;
+-
+-	contexts = fds + size;
+-	if (pfds->size) {
+-		memcpy(fds, pfds->fds, pfds->size * sizeof(*pfds->fds));
+-		memcpy(contexts, pfds->context, pfds->size * sizeof(*pfds->context));
+-		free(pfds->fds);
+-	}
+-
+-	while (pfds->size < size)
+-		fds[pfds->size++].fd = INVALID_SOCKET;
+-
+-	pfds->fds = fds;
+-	pfds->context = contexts;
+-	return FI_SUCCESS;
+-}
+-
+ int ofi_pollfds_create(struct ofi_pollfds **pfds)
+ {
+ 	int ret;
+@@ -1346,9 +1314,14 @@ int ofi_pollfds_create(struct ofi_pollfds **pfds)
+ 	if (!*pfds)
+ 		return -FI_ENOMEM;
+ 
+-	ret = ofi_pollfds_grow(*pfds, 63);
+-	if (ret)
++	(*pfds)->size = 64;
++	(*pfds)->fds = calloc((*pfds)->size, sizeof(*(*pfds)->fds) +
++			    sizeof(*(*pfds)->context));
++	if (!(*pfds)->fds) {
++		ret = -FI_ENOMEM;
+ 		goto err1;
++	}
++	(*pfds)->context = (void *)((*pfds)->fds + (*pfds)->size);
+ 
+ 	ret = fd_signal_init(&(*pfds)->signal);
+ 	if (ret)
+@@ -1416,12 +1389,16 @@ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+ {
+ 	struct slist_entry *entry;
+ 	struct ofi_pollfds_work_item *item;
+-	int ret;
++	int i;
+ 
+ 	fastlock_acquire(&pfds->lock);
+-	ret = ofi_pollfds_do_mod(pfds, fd, events, context);
+-	if (!ret)
+-		goto signal;
++	for (i = 1; i < pfds->nfds; i++) {
++		if (pfds->fds[i].fd == fd) {
++			pfds->fds[i].events = events;
++			pfds->context[i] = context;
++			goto signal;
++		}
++	}
+ 
+ 	/* fd may be queued for insertion */
+ 	entry = slist_find_first_match(&pfds->work_item_list, ofi_pollfds_find,
+@@ -1443,28 +1420,83 @@ int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
+ 	return ofi_pollfds_ctl(pfds, POLLFDS_CTL_DEL, fd, 0, NULL);
+ }
+ 
++static int ofi_pollfds_array(struct ofi_pollfds *pfds)
++{
++	struct pollfd *fds;
++	void *contexts;
++
++	fds = calloc(pfds->size + 64,
++		     sizeof(*pfds->fds) + sizeof(*pfds->context));
++	if (!fds)
++		return -FI_ENOMEM;
++
++	pfds->size += 64;
++	contexts = fds + pfds->size;
++
++	memcpy(fds, pfds->fds, pfds->nfds * sizeof(*pfds->fds));
++	memcpy(contexts, pfds->context, pfds->nfds * sizeof(*pfds->context));
++	free(pfds->fds);
++	pfds->fds = fds;
++	pfds->context = contexts;
++	return FI_SUCCESS;
++}
++
++static void ofi_pollfds_cleanup(struct ofi_pollfds *pfds)
++{
++	int i;
++
++	for (i = 0; i < pfds->nfds; i++) {
++		while (pfds->fds[i].fd == INVALID_SOCKET) {
++			pfds->nfds--;
++			if (i == pfds->nfds)
++				break;
++
++			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
++			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
++			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
++			pfds->context[i] = pfds->context[pfds->nfds];
++		}
++	}
++}
++
+ static void ofi_pollfds_process_work(struct ofi_pollfds *pfds)
+ {
+ 	struct slist_entry *entry;
+ 	struct ofi_pollfds_work_item *item;
++	int i;
+ 
+ 	while (!slist_empty(&pfds->work_item_list)) {
++		if ((pfds->nfds == pfds->size) &&
++		    ofi_pollfds_array(pfds))
++			continue;
++
+ 		entry = slist_remove_head(&pfds->work_item_list);
+ 		item = container_of(entry, struct ofi_pollfds_work_item, entry);
+ 
+ 		switch (item->type) {
+ 		case POLLFDS_CTL_ADD:
+-			ofi_pollfds_do_add(pfds, item);
++			pfds->fds[pfds->nfds].fd = item->fd;
++			pfds->fds[pfds->nfds].events = item->events;
++			pfds->fds[pfds->nfds].revents = 0;
++			pfds->context[pfds->nfds] = item->context;
++			pfds->nfds++;
+ 			break;
+ 		case POLLFDS_CTL_DEL:
+-			ofi_pollfds_do_del(pfds, item);
++			for (i = 0; i < pfds->nfds; i++) {
++				if (pfds->fds[i].fd == item->fd) {
++					pfds->fds[i].fd = INVALID_SOCKET;
++					break;
++				}
++			}
+ 			break;
+ 		default:
+ 			assert(0);
+-			break;
++			goto out;
+ 		}
+ 		free(item);
+ 	}
++out:
++	ofi_pollfds_cleanup(pfds);
+ }
+ 
+ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
+diff --git a/src/unix/osd.c b/src/unix/osd.c
+index e32b05ae3de3..ac11573a623d 100644
+--- a/src/unix/osd.c
++++ b/src/unix/osd.c
+@@ -296,45 +296,3 @@ int ofi_set_thread_affinity(const char *s)
+ 	return -FI_ENOSYS;
+ #endif
+ }
+-
+-
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (item->fd >= pfds->size) {
+-		if (ofi_pollfds_grow(pfds, item->fd))
+-			return;
+-	}
+-
+-	pfds->fds[item->fd].fd = item->fd;
+-	pfds->fds[item->fd].events = item->events;
+-	pfds->fds[item->fd].revents = 0;
+-	pfds->context[item->fd] = item->context;
+-	if (item->fd >= pfds->nfds)
+-		pfds->nfds = item->fd + 1;
+-}
+-
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context)
+-{
+-	if ((fd < pfds->nfds) && (pfds->fds[fd].fd == fd)) {
+-		pfds->fds[fd].events = events;
+-		pfds->context[fd] = context;
+-		return FI_SUCCESS;
+-	}
+-
+-	return -FI_ENOENT;
+-}
+-
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (item->fd >= pfds->nfds)
+-		return;
+-
+-	pfds->fds[item->fd].fd = INVALID_SOCKET;
+-	pfds->fds[item->fd].events = 0;
+-	pfds->fds[item->fd].revents = 0;
+-	while (pfds->nfds && pfds->fds[pfds->nfds - 1].fd == INVALID_SOCKET)
+-		pfds->nfds--;
+-}
+diff --git a/src/windows/osd.c b/src/windows/osd.c
+index 83ce12acbded..7c0005d4ecc7 100644
+--- a/src/windows/osd.c
++++ b/src/windows/osd.c
+@@ -600,55 +600,3 @@ ssize_t ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
+ 	ret = WSARecvMsg(fd, msg, &bytes, NULL, NULL);
+ 	return ret ? ret : bytes;
+ }
+-
+-
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (pfds->nfds == pfds->size) {
+-		if (ofi_pollfds_grow(pfds, pfds->size + 1))
+-			return;
+-	}
+-
+-	pfds->fds[pfds->nfds].fd = item->fd;
+-	pfds->fds[pfds->nfds].events = item->events;
+-	pfds->fds[pfds->nfds].revents = 0;
+-	pfds->context[pfds->nfds] = item->context;
+-	pfds->nfds++;
+-}
+-
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context)
+-{
+-	int i;
+-
+-	/* 0 is signaling fd */
+-	for (i = 1; i < pfds->nfds; i++) {
+-		if (pfds->fds[i].fd == fd) {
+-			pfds->fds[i].events = events;
+-			pfds->context[i] = context;
+-			return FI_SUCCESS;
+-		}
+-	}
+-
+-	return -FI_ENOENT;
+-}
+-
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	int i;
+-
+-	for (i = 0; i < pfds->nfds; i++) {
+-		if (pfds->fds[i].fd == item->fd) {
+-			pfds->fds[i].fd = INVALID_SOCKET;
+-
+-			pfds->nfds--;
+-			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
+-			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
+-			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
+-			pfds->context[i] = pfds->context[pfds->nfds];
+-			break;
+-		}
+-	}
+-}

--- a/tcp_provider.patch
+++ b/tcp_provider.patch
@@ -1,0 +1,33 @@
+diff --git a/prov/tcp/src/tcpx_progress.c b/prov/tcp/src/tcpx_progress.c
+index 568a5918f04b..eaea4874143a 100644
+--- a/prov/tcp/src/tcpx_progress.c
++++ b/prov/tcp/src/tcpx_progress.c
+@@ -796,7 +796,7 @@ int tcpx_try_func(void *util_ep)
+ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
+ 			  struct tcpx_xfer_entry *tx_entry)
+ {
+-	struct util_wait *wait = ep->util_ep.tx_cq->wait;
++	struct util_wait *rx_wait, *tx_wait;
+ 
+ 	if (!ep->cur_tx.entry) {
+ 		ep->cur_tx.entry = tx_entry;
+@@ -805,8 +805,17 @@ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
+ 		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
+ 		tcpx_progress_tx(ep);
+ 
+-		if (!ep->cur_tx.entry && wait)
+-			wait->signal(wait);
++		/* Wake-up blocked threads if they need to add POLLOUT to
++		 * their events to monitor for this socket.
++		 */
++		tx_wait = ep->util_ep.tx_cq->wait;
++		rx_wait = ep->util_ep.rx_cq->wait;
++		if (ep->cur_tx.entry) {
++			if (tx_wait)
++				tx_wait->signal(tx_wait);
++			if (rx_wait && rx_wait != tx_wait)
++				rx_wait->signal(rx_wait);
++		}
+ 	} else if (tx_entry->ctrl_flags & TCPX_INTERNAL_XFER) {
+ 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);
+ 	} else {


### PR DESCRIPTION
Revert patch with performance degradation and
apply the following patch for TCP provider.

Commit 45dce66 incorrectly negated a check that is used to signal
any threads waiting on a cq to wake up. Without this signal,
applications can hang, as reported in issue 7443. The situation is
as follows:

A thread waits for completions on the CQ. At the time that the thread
blocks, the socket has no outgoing transfers, so the thread calls
poll looking for a POLLIN event.

Another thread tries to send a large transfer. A portion of the data
is accepted by the socket. The rest of the transfer is queued on the ep.
That thread returns. Additional messages may be posted to the ep, but
since there's already an active transfer, those messages simply get
queued on the tx_queue.

Note that the thread that was blocked on the CQ is still blocked waiting
for a POLLIN event. However, it should be waiting for POLLOUT | POLLIN.
The signal in this case isn't trying to drive progress, like the original
commit suggests, but is needed to update the poll call.

Reverse the check, so that blocked threads wake up and can update their
poll event status.

Signed-off-by: Sean Hefty sean.hefty@intel.com