### PR TITLE
DAOS-9883 libfabric: Revert "DAOS-9883 libfabric: Upgrade to 1.15.0~r…

### DIFF
--- a/daos-9173-ofi.patch
+++ b/daos-9173-ofi.patch
@@ -1,0 +1,180 @@
+diff --git a/prov/verbs/src/fi_verbs.h b/prov/verbs/src/fi_verbs.h
+index 29ff483..5ccd04b 100644
+--- a/prov/verbs/src/fi_verbs.h
++++ b/prov/verbs/src/fi_verbs.h
+@@ -577,6 +577,7 @@ struct vrb_ep {
+ 	/* Protected by send CQ lock */
+ 	uint64_t			sq_credits;
+ 	uint64_t			peer_rq_credits;
++	struct slist			sq_list;
+ 	/* Protected by recv CQ lock */
+ 	int64_t				rq_credits_avail;
+ 	int64_t				threshold;
+@@ -619,15 +620,22 @@ struct vrb_ep {
+ };
+ 
+ 
+-/* Must be cast-able to struct fi_context */
++enum vrb_op_ctx {
++	VRB_POST_SQ,
++	VRB_POST_RQ,
++	VRB_POST_SRQ,
++};
++
+ struct vrb_context {
+-	struct vrb_ep			*ep;
+-	struct vrb_srq_ep		*srx;
++	struct slist_entry		entry;
++	union {
++		struct vrb_ep		*ep;
++		struct vrb_srq_ep	*srx;
++	};
+ 	void				*user_ctx;
+-	uint32_t			flags;
++	enum vrb_op_ctx			op_ctx;
+ };
+ 
+-
+ #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
+ struct vrb_xrc_ep {
+ 	/* Must be first */
+diff --git a/prov/verbs/src/verbs_cq.c b/prov/verbs/src/verbs_cq.c
+index 5419824..e8f306b 100644
+--- a/prov/verbs/src/verbs_cq.c
++++ b/prov/verbs/src/verbs_cq.c
+@@ -239,18 +239,22 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
+ 
+ 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
+ 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+-		if (ctx->flags & FI_TRANSMIT) {
++		if (ctx->op_ctx == VRB_POST_SQ) {
++			assert(ctx->ep);
++			assert(!slist_empty(&ctx->ep->sq_list));
++			assert(ctx->ep->sq_list.head == &ctx->entry);
++			(void) slist_remove_head(&ctx->ep->sq_list);
+ 			cq->credits++;
+ 			ctx->ep->sq_credits++;
+ 		}
+ 
+ 		if (wc->status) {
+-			if (ctx->flags & FI_RECV)
+-				wc->opcode |= IBV_WC_RECV;
+-			else
++			if (ctx->op_ctx == VRB_POST_SQ)
+ 				wc->opcode &= ~IBV_WC_RECV;
++			else
++				wc->opcode |= IBV_WC_RECV;
+ 		}
+-		if (ctx->srx) {
++		if (ctx->op_ctx == VRB_POST_SRQ) {
+ 			fastlock_acquire(&ctx->srx->ctx_lock);
+ 			ofi_buf_free(ctx);
+ 			fastlock_release(&ctx->srx->ctx_lock);
+diff --git a/prov/verbs/src/verbs_ep.c b/prov/verbs/src/verbs_ep.c
+index bae5b15..a60c892 100644
+--- a/prov/verbs/src/verbs_ep.c
++++ b/prov/verbs/src/verbs_ep.c
+@@ -69,9 +69,9 @@ ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr)
+ 	if (!ctx)
+ 		goto unlock;
+ 
+-	ctx->ep = ep;
++	OFI_DBG_SET(ctx->ep, ep);
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->flags = FI_RECV;
++	ctx->op_ctx = VRB_POST_RQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_recv(ep->ibv_qp, wr, &bad_wr);
+@@ -143,7 +143,7 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
+ 
+ 	ctx->ep = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->flags = FI_TRANSMIT | flags;
++	ctx->op_ctx = VRB_POST_SQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_send(ep->ibv_qp, wr, &bad_wr);
+@@ -153,6 +153,7 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
+ 			 vrb_convert_ret(ret));
+ 		goto credits;
+ 	}
++	slist_insert_tail(&ctx->entry, &ep->sq_list);
+ 	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+ 
+ 	return 0;
+@@ -391,6 +392,7 @@ vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
+ 		goto err2;
+ 	}
+ 
++	slist_init(&ep->sq_list);
+ 	ep->util_ep.ep_fid.msg = calloc(1, sizeof(*ep->util_ep.ep_fid.msg));
+ 	if (!ep->util_ep.ep_fid.msg)
+ 		goto err3;
+@@ -405,6 +407,41 @@ err1:
+ 	return NULL;
+ }
+ 
++/* Generate flush completion entries for any queued send requests.
++ * We only need to record the wr_id and that the entry was not a
++ * receive (indicated by lack of IBV_WC_RECV flag).
++ */
++static void vrb_flush_sq(struct vrb_ep *ep)
++{
++	struct vrb_context *ctx;
++	struct vrb_cq *cq;
++	struct slist_entry *entry;
++	struct ibv_wc wc = {0};
++
++	if (!ep->util_ep.tx_cq)
++		return;
++
++	cq = container_of(ep->util_ep.tx_cq, struct vrb_cq, util_cq);
++	wc.status = IBV_WC_WR_FLUSH_ERR;
++	wc.vendor_err = FI_ECANCELED;
++
++	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
++	while (!slist_empty(&ep->sq_list)) {
++		entry = slist_remove_head(&ep->sq_list);
++		ctx = container_of(entry, struct vrb_context, entry);
++		assert(ctx->op_ctx == VRB_POST_SQ);
++
++		wc.wr_id = (uintptr_t) ctx->user_ctx;
++		cq->credits++;
++		ctx->ep->sq_credits++;
++		ofi_buf_free(ctx);
++
++		if (wc.wr_id != VERBS_NO_COMP_FLAG)
++			vrb_save_wc(cq, &wc);
++	}
++	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
++}
++
+ static int vrb_close_free_ep(struct vrb_ep *ep)
+ {
+ 	struct vrb_cq *cq;
+@@ -478,6 +515,7 @@ static int vrb_ep_close(fid_t fid)
+ 		if (ep->eq)
+ 			fastlock_release(&ep->eq->lock);
+ 		vrb_cleanup_cq(ep);
++		vrb_flush_sq(ep);
+ 		break;
+ 	case FI_EP_DGRAM:
+ 		fab = container_of(&ep->util_ep.domain->fabric->fabric_fid,
+@@ -490,6 +528,7 @@ static int vrb_ep_close(fid_t fid)
+ 			return -errno;
+ 		}
+ 		vrb_cleanup_cq(ep);
++		vrb_flush_sq(ep);
+ 		break;
+ 	default:
+ 		VRB_WARN(FI_LOG_DOMAIN, "Unknown EP type\n");
+@@ -1464,7 +1503,7 @@ ssize_t vrb_post_srq(struct vrb_srq_ep *ep, struct ibv_recv_wr *wr)
+ 
+ 	ctx->srx = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->flags = FI_RECV;
++	ctx->op_ctx = VRB_POST_SRQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_srq_recv(ep->srq, wr, &bad_wr);

--- a/daos-9376-ofi.patch
+++ b/daos-9376-ofi.patch
@@ -1,0 +1,145 @@
+diff --git a/prov/verbs/src/fi_verbs.h b/prov/verbs/src/fi_verbs.h
+index 3424236b6b..f770f59479 100644
+--- a/prov/verbs/src/fi_verbs.h
++++ b/prov/verbs/src/fi_verbs.h
+@@ -620,10 +620,10 @@ struct vrb_ep {
+ };
+ 
+ 
+-enum vrb_op_ctx {
+-	VRB_POST_SQ,
+-	VRB_POST_RQ,
+-	VRB_POST_SRQ,
++enum vrb_op_queue {
++	VRB_OP_SQ,
++	VRB_OP_RQ,
++	VRB_OP_SRQ,
+ };
+ 
+ struct vrb_context {
+@@ -633,9 +633,12 @@ struct vrb_context {
+ 		struct vrb_srq_ep	*srx;
+ 	};
+ 	void				*user_ctx;
+-	enum vrb_op_ctx			op_ctx;
++	enum vrb_op_queue		op_queue;
++	enum ibv_wr_opcode		sq_opcode;
+ };
+ 
++enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr);
++
+ #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
+ struct vrb_xrc_ep {
+ 	/* Must be first */
+diff --git a/prov/verbs/src/verbs_cq.c b/prov/verbs/src/verbs_cq.c
+index 49be93c730..276f932c05 100644
+--- a/prov/verbs/src/verbs_cq.c
++++ b/prov/verbs/src/verbs_cq.c
+@@ -37,6 +37,22 @@
+ 
+ #include "fi_verbs.h"
+ 
++
++enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr)
++{
++	static enum ibv_wc_opcode wc[] = {
++		[IBV_WR_RDMA_WRITE] = IBV_WC_RDMA_WRITE,
++		[IBV_WR_RDMA_WRITE_WITH_IMM] = IBV_WC_RDMA_WRITE,
++		[IBV_WR_SEND] = IBV_WC_SEND,
++		[IBV_WR_SEND_WITH_IMM] = IBV_WC_SEND,
++		[IBV_WR_RDMA_READ] = IBV_WC_RDMA_READ,
++		[IBV_WR_ATOMIC_CMP_AND_SWP] = IBV_WC_COMP_SWAP,
++		[IBV_WR_ATOMIC_FETCH_AND_ADD] = IBV_WC_FETCH_ADD,
++	};
++
++	return (wr < ARRAY_SIZE(wc)) ? wc[wr] : IBV_WC_SEND;
++}
++
+ static void vrb_cq_read_context_entry(struct ibv_wc *wc, void *buf)
+ {
+ 	struct fi_cq_entry *entry = buf;
+@@ -239,7 +255,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
+ 
+ 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
+ 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+-		if (ctx->op_ctx == VRB_POST_SQ) {
++		if (ctx->op_queue == VRB_OP_SQ) {
+ 			assert(ctx->ep);
+ 			assert(!slist_empty(&ctx->ep->sq_list));
+ 			assert(ctx->ep->sq_list.head == &ctx->entry);
+@@ -248,13 +264,11 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
+ 			ctx->ep->sq_credits++;
+ 		}
+ 
+-		if (wc->status) {
+-			if (ctx->op_ctx == VRB_POST_SQ)
+-				wc->opcode &= ~IBV_WC_RECV;
+-			else
+-				wc->opcode |= IBV_WC_RECV;
+-		}
+-		if (ctx->op_ctx == VRB_POST_SRQ) {
++		/* workaround incorrect opcode reported by verbs */
++		wc->opcode = (ctx->op_queue == VRB_OP_SQ) ?
++			     vrb_wr2wc_opcode(ctx->sq_opcode) : IBV_WC_RECV;
++
++		if (ctx->op_queue == VRB_OP_SRQ) {
+ 			fastlock_acquire(&ctx->srx->ctx_lock);
+ 			ofi_buf_free(ctx);
+ 			fastlock_release(&ctx->srx->ctx_lock);
+diff --git a/prov/verbs/src/verbs_ep.c b/prov/verbs/src/verbs_ep.c
+index c11e990610..632ad799be 100644
+--- a/prov/verbs/src/verbs_ep.c
++++ b/prov/verbs/src/verbs_ep.c
+@@ -71,7 +71,7 @@ ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr)
+ 
+ 	OFI_DBG_SET(ctx->ep, ep);
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_RQ;
++	ctx->op_queue = VRB_OP_RQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_recv(ep->ibv_qp, wr, &bad_wr);
+@@ -143,7 +143,8 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
+ 
+ 	ctx->ep = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_SQ;
++	ctx->op_queue = VRB_OP_SQ;
++	ctx->sq_opcode = wr->opcode;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_send(ep->ibv_qp, wr, &bad_wr);
+@@ -407,10 +408,7 @@ vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
+ 	return NULL;
+ }
+ 
+-/* Generate flush completion entries for any queued send requests.
+- * We only need to record the wr_id and that the entry was not a
+- * receive (indicated by lack of IBV_WC_RECV flag).
+- */
++/* Generate flush completion entries for any queued send requests. */
+ static void vrb_flush_sq(struct vrb_ep *ep)
+ {
+ 	struct vrb_context *ctx;
+@@ -429,9 +427,11 @@ static void vrb_flush_sq(struct vrb_ep *ep)
+ 	while (!slist_empty(&ep->sq_list)) {
+ 		entry = slist_remove_head(&ep->sq_list);
+ 		ctx = container_of(entry, struct vrb_context, entry);
+-		assert(ctx->op_ctx == VRB_POST_SQ);
++		assert(ctx->op_queue == VRB_OP_SQ);
+ 
+ 		wc.wr_id = (uintptr_t) ctx->user_ctx;
++		wc.opcode = vrb_wr2wc_opcode(ctx->sq_opcode);
++
+ 		cq->credits++;
+ 		ctx->ep->sq_credits++;
+ 		ofi_buf_free(ctx);
+@@ -1503,7 +1503,7 @@ ssize_t vrb_post_srq(struct vrb_srq_ep *ep, struct ibv_recv_wr *wr)
+ 
+ 	ctx->srx = ep;
+ 	ctx->user_ctx = (void *) (uintptr_t) wr->wr_id;
+-	ctx->op_ctx = VRB_POST_SRQ;
++	ctx->op_queue = VRB_OP_SRQ;
+ 	wr->wr_id = (uintptr_t) ctx;
+ 
+ 	ret = ibv_post_srq_recv(ep->srq, wr, &bad_wr);

--- a/revert.patch
+++ b/revert.patch
@@ -1,0 +1,313 @@
+commit d8f2b3db73c8556949681f319d6dde7f0fc30cc0
+Author: Dmitry Eremin <dmitry.eremin@intel.com>
+Date:   Sat Apr 2 13:37:50 2022 +0300
+
+    Revert "core/pollfds: Use direct indexing instead of searches"
+    
+    This reverts commit 7ec82992a7c9a4c989e55d8d9a23aa43219e80f3.
+
+diff --git a/include/ofi_epoll.h b/include/ofi_epoll.h
+index de50d847004d..dad5844a91ee 100644
+--- a/include/ofi_epoll.h
++++ b/include/ofi_epoll.h
+@@ -82,7 +82,6 @@ struct ofi_pollfds {
+ };
+ 
+ int ofi_pollfds_create(struct ofi_pollfds **pfds);
+-int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
+ int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
+ 		    void *context);
+ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+@@ -93,14 +92,6 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
+ 		     int maxevents, int timeout);
+ void ofi_pollfds_close(struct ofi_pollfds *pfds);
+ 
+-/* OS specific */
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item);
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context);
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item);
+-
+ 
+ #ifdef HAVE_EPOLL
+ #include <sys/epoll.h>
+diff --git a/src/common.c b/src/common.c
+index 6206b8825e38..57283e8c7bdd 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -1306,38 +1306,6 @@ uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
+ }
+ #endif
+ 
+-int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size)
+-{
+-	struct pollfd *fds;
+-	void *contexts;
+-	size_t size;
+-
+-	if (max_size < pfds->size)
+-		return FI_SUCCESS;
+-
+-	size = max_size + 1;
+-	if (size < pfds->size + 64)
+-		size = pfds->size + 64;
+-
+-	fds = calloc(size, sizeof(*pfds->fds) + sizeof(*pfds->context));
+-	if (!fds)
+-		return -FI_ENOMEM;
+-
+-	contexts = fds + size;
+-	if (pfds->size) {
+-		memcpy(fds, pfds->fds, pfds->size * sizeof(*pfds->fds));
+-		memcpy(contexts, pfds->context, pfds->size * sizeof(*pfds->context));
+-		free(pfds->fds);
+-	}
+-
+-	while (pfds->size < size)
+-		fds[pfds->size++].fd = INVALID_SOCKET;
+-
+-	pfds->fds = fds;
+-	pfds->context = contexts;
+-	return FI_SUCCESS;
+-}
+-
+ int ofi_pollfds_create(struct ofi_pollfds **pfds)
+ {
+ 	int ret;
+@@ -1346,9 +1314,14 @@ int ofi_pollfds_create(struct ofi_pollfds **pfds)
+ 	if (!*pfds)
+ 		return -FI_ENOMEM;
+ 
+-	ret = ofi_pollfds_grow(*pfds, 63);
+-	if (ret)
++	(*pfds)->size = 64;
++	(*pfds)->fds = calloc((*pfds)->size, sizeof(*(*pfds)->fds) +
++			    sizeof(*(*pfds)->context));
++	if (!(*pfds)->fds) {
++		ret = -FI_ENOMEM;
+ 		goto err1;
++	}
++	(*pfds)->context = (void *)((*pfds)->fds + (*pfds)->size);
+ 
+ 	ret = fd_signal_init(&(*pfds)->signal);
+ 	if (ret)
+@@ -1416,12 +1389,16 @@ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+ {
+ 	struct slist_entry *entry;
+ 	struct ofi_pollfds_work_item *item;
+-	int ret;
++	int i;
+ 
+ 	fastlock_acquire(&pfds->lock);
+-	ret = ofi_pollfds_do_mod(pfds, fd, events, context);
+-	if (!ret)
+-		goto signal;
++	for (i = 1; i < pfds->nfds; i++) {
++		if (pfds->fds[i].fd == fd) {
++			pfds->fds[i].events = events;
++			pfds->context[i] = context;
++			goto signal;
++		}
++	}
+ 
+ 	/* fd may be queued for insertion */
+ 	entry = slist_find_first_match(&pfds->work_item_list, ofi_pollfds_find,
+@@ -1443,28 +1420,83 @@ int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
+ 	return ofi_pollfds_ctl(pfds, POLLFDS_CTL_DEL, fd, 0, NULL);
+ }
+ 
++static int ofi_pollfds_array(struct ofi_pollfds *pfds)
++{
++	struct pollfd *fds;
++	void *contexts;
++
++	fds = calloc(pfds->size + 64,
++		     sizeof(*pfds->fds) + sizeof(*pfds->context));
++	if (!fds)
++		return -FI_ENOMEM;
++
++	pfds->size += 64;
++	contexts = fds + pfds->size;
++
++	memcpy(fds, pfds->fds, pfds->nfds * sizeof(*pfds->fds));
++	memcpy(contexts, pfds->context, pfds->nfds * sizeof(*pfds->context));
++	free(pfds->fds);
++	pfds->fds = fds;
++	pfds->context = contexts;
++	return FI_SUCCESS;
++}
++
++static void ofi_pollfds_cleanup(struct ofi_pollfds *pfds)
++{
++	int i;
++
++	for (i = 0; i < pfds->nfds; i++) {
++		while (pfds->fds[i].fd == INVALID_SOCKET) {
++			pfds->nfds--;
++			if (i == pfds->nfds)
++				break;
++
++			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
++			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
++			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
++			pfds->context[i] = pfds->context[pfds->nfds];
++		}
++	}
++}
++
+ static void ofi_pollfds_process_work(struct ofi_pollfds *pfds)
+ {
+ 	struct slist_entry *entry;
+ 	struct ofi_pollfds_work_item *item;
++	int i;
+ 
+ 	while (!slist_empty(&pfds->work_item_list)) {
++		if ((pfds->nfds == pfds->size) &&
++		    ofi_pollfds_array(pfds))
++			continue;
++
+ 		entry = slist_remove_head(&pfds->work_item_list);
+ 		item = container_of(entry, struct ofi_pollfds_work_item, entry);
+ 
+ 		switch (item->type) {
+ 		case POLLFDS_CTL_ADD:
+-			ofi_pollfds_do_add(pfds, item);
++			pfds->fds[pfds->nfds].fd = item->fd;
++			pfds->fds[pfds->nfds].events = item->events;
++			pfds->fds[pfds->nfds].revents = 0;
++			pfds->context[pfds->nfds] = item->context;
++			pfds->nfds++;
+ 			break;
+ 		case POLLFDS_CTL_DEL:
+-			ofi_pollfds_do_del(pfds, item);
++			for (i = 0; i < pfds->nfds; i++) {
++				if (pfds->fds[i].fd == item->fd) {
++					pfds->fds[i].fd = INVALID_SOCKET;
++					break;
++				}
++			}
+ 			break;
+ 		default:
+ 			assert(0);
+-			break;
++			goto out;
+ 		}
+ 		free(item);
+ 	}
++out:
++	ofi_pollfds_cleanup(pfds);
+ }
+ 
+ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
+diff --git a/src/unix/osd.c b/src/unix/osd.c
+index e32b05ae3de3..ac11573a623d 100644
+--- a/src/unix/osd.c
++++ b/src/unix/osd.c
+@@ -296,45 +296,3 @@ int ofi_set_thread_affinity(const char *s)
+ 	return -FI_ENOSYS;
+ #endif
+ }
+-
+-
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (item->fd >= pfds->size) {
+-		if (ofi_pollfds_grow(pfds, item->fd))
+-			return;
+-	}
+-
+-	pfds->fds[item->fd].fd = item->fd;
+-	pfds->fds[item->fd].events = item->events;
+-	pfds->fds[item->fd].revents = 0;
+-	pfds->context[item->fd] = item->context;
+-	if (item->fd >= pfds->nfds)
+-		pfds->nfds = item->fd + 1;
+-}
+-
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context)
+-{
+-	if ((fd < pfds->nfds) && (pfds->fds[fd].fd == fd)) {
+-		pfds->fds[fd].events = events;
+-		pfds->context[fd] = context;
+-		return FI_SUCCESS;
+-	}
+-
+-	return -FI_ENOENT;
+-}
+-
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (item->fd >= pfds->nfds)
+-		return;
+-
+-	pfds->fds[item->fd].fd = INVALID_SOCKET;
+-	pfds->fds[item->fd].events = 0;
+-	pfds->fds[item->fd].revents = 0;
+-	while (pfds->nfds && pfds->fds[pfds->nfds - 1].fd == INVALID_SOCKET)
+-		pfds->nfds--;
+-}
+diff --git a/src/windows/osd.c b/src/windows/osd.c
+index 83ce12acbded..7c0005d4ecc7 100644
+--- a/src/windows/osd.c
++++ b/src/windows/osd.c
+@@ -600,55 +600,3 @@ ssize_t ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
+ 	ret = WSARecvMsg(fd, msg, &bytes, NULL, NULL);
+ 	return ret ? ret : bytes;
+ }
+-
+-
+-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	if (pfds->nfds == pfds->size) {
+-		if (ofi_pollfds_grow(pfds, pfds->size + 1))
+-			return;
+-	}
+-
+-	pfds->fds[pfds->nfds].fd = item->fd;
+-	pfds->fds[pfds->nfds].events = item->events;
+-	pfds->fds[pfds->nfds].revents = 0;
+-	pfds->context[pfds->nfds] = item->context;
+-	pfds->nfds++;
+-}
+-
+-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+-		       void *context)
+-{
+-	int i;
+-
+-	/* 0 is signaling fd */
+-	for (i = 1; i < pfds->nfds; i++) {
+-		if (pfds->fds[i].fd == fd) {
+-			pfds->fds[i].events = events;
+-			pfds->context[i] = context;
+-			return FI_SUCCESS;
+-		}
+-	}
+-
+-	return -FI_ENOENT;
+-}
+-
+-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+-			struct ofi_pollfds_work_item *item)
+-{
+-	int i;
+-
+-	for (i = 0; i < pfds->nfds; i++) {
+-		if (pfds->fds[i].fd == item->fd) {
+-			pfds->fds[i].fd = INVALID_SOCKET;
+-
+-			pfds->nfds--;
+-			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
+-			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
+-			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
+-			pfds->context[i] = pfds->context[pfds->nfds];
+-			break;
+-		}
+-	}
+-}

--- a/tcp_provider.patch
+++ b/tcp_provider.patch
@@ -1,0 +1,33 @@
+diff --git a/prov/tcp/src/tcpx_progress.c b/prov/tcp/src/tcpx_progress.c
+index 568a5918f04b..eaea4874143a 100644
+--- a/prov/tcp/src/tcpx_progress.c
++++ b/prov/tcp/src/tcpx_progress.c
+@@ -796,7 +796,7 @@ int tcpx_try_func(void *util_ep)
+ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
+ 			  struct tcpx_xfer_entry *tx_entry)
+ {
+-	struct util_wait *wait = ep->util_ep.tx_cq->wait;
++	struct util_wait *rx_wait, *tx_wait;
+ 
+ 	if (!ep->cur_tx.entry) {
+ 		ep->cur_tx.entry = tx_entry;
+@@ -805,8 +805,17 @@ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
+ 		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
+ 		tcpx_progress_tx(ep);
+ 
+-		if (!ep->cur_tx.entry && wait)
+-			wait->signal(wait);
++		/* Wake-up blocked threads if they need to add POLLOUT to
++		 * their events to monitor for this socket.
++		 */
++		tx_wait = ep->util_ep.tx_cq->wait;
++		rx_wait = ep->util_ep.rx_cq->wait;
++		if (ep->cur_tx.entry) {
++			if (tx_wait)
++				tx_wait->signal(tx_wait);
++			if (rx_wait && rx_wait != tx_wait)
++				rx_wait->signal(rx_wait);
++		}
+ 	} else if (tx_entry->ctrl_flags & TCPX_INTERNAL_XFER) {
+ 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);
+ 	} else {


### PR DESCRIPTION
…c3-1"

Put old patches back since other branches still need them.

This reverts partially commit d98e47cc8c35eba11079c8d93e7b4f3546a87c8a.

Signed-off-by: Lei Huang <wiliam_huang@hotmail.com>