### PR TITLE
DAOS-10828 libfabric: add CXI patch to keep backward compatibility with v1.14.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfabric (1.15.1-2) unstable; urgency=medium
+  [ Jerome Soumagne ]
+  * Add patch to keep backward compatibility with CXI provider using v1.14.x
+
+ -- Jerome Soumagne <jerome.soumagne@intel.com>  Tue, 05 July 2022 16:00:00 -0500
+
 libfabric (1.15.1-1) unstable; urgency=medium
   [ Lei Huang ]
   * Update to 1.15.1 to get the patch to fix the tcp performance issue in 1.14

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -9,7 +9,7 @@
 
 Name: libfabric
 Version: %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 License: GPLv2 or BSD
 %if 0%{?suse_version} >= 1315
@@ -19,6 +19,7 @@ Group: System Environment/Libraries
 %endif
 Url: https://www.github.com/ofiwg/libfabric
 Source: https://github.com/ofiwg/%{name}/archive/v%{dl_version}.tar.gz
+Patch0: cxi_provider.patch
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel >= 1.0.16
@@ -151,6 +152,9 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
+* Tue Jul  5 2022 Jerome Soumagne <jerome.soumagne@intel.com> - 1.15.1-2
+- Add patch to keep backward compatibility with CXI provider using v1.14.x
+
 * Wed May 18 2022 Lei Huang <lei.huang@intel.com> - 1.15.1-1
 - Update to v1.15.1
 

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -98,27 +98,29 @@ define distro_map
 endef
 
 define install_repos
-	IFS='|' read -ra BASES <<< "$($(DISTRO_BASE)_LOCAL_REPOS)";         \
-	for baseurl in "$${BASES[@]}"; do                                   \
-	    baseurl="$${baseurl# *}";                                       \
-	    $(call install_repo,$$baseurl);                                 \
-	done
-	for repo in $($(DISTRO_BASE)_PR_REPOS)                              \
-	            $(PR_REPOS) $(1); do                                    \
-	    branch="master";                                                \
-	    build_number="lastSuccessfulBuild";                             \
-	    if [[ $$repo = *@* ]]; then                                     \
-	        branch="$${repo#*@}";                                       \
-	        repo="$${repo%@*}";                                         \
-	        if [[ $$branch = *:* ]]; then                               \
-	            build_number="$${branch#*:}";                           \
-	            branch="$${branch%:*}";                                 \
-	        fi;                                                         \
-	    fi;                                                             \
-	    $(call distro_map)                                              \
+	if [ "$(ID_LIKE)" = "debian" ]; then                            \
+	    IFS='|' read -ra BASES <<< "$($(DISTRO_BASE)_LOCAL_REPOS)"; \
+	    for baseurl in "$${BASES[@]}"; do                           \
+	        baseurl="$${baseurl# *}";                               \
+	        $(call install_repo,$$baseurl)                          \
+	    done;                                                       \
+	fi
+	for repo in $($(DISTRO_BASE)_PR_REPOS)                                                             \
+	            $(PR_REPOS) $(1); do                                                                   \
+	    branch="master";                                                                               \
+	    build_number="lastSuccessfulBuild";                                                            \
+	    if [[ $$repo = *@* ]]; then                                                                    \
+	        branch="$${repo#*@}";                                                                      \
+	        repo="$${repo%@*}";                                                                        \
+	        if [[ $$branch = *:* ]]; then                                                              \
+	            build_number="$${branch#*:}";                                                          \
+	            branch="$${branch%:*}";                                                                \
+	        fi;                                                                                        \
+	    fi;                                                                                            \
+	    $(call distro_map)                                                                             \
 	    baseurl=$${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$$repo/job/$$branch/; \
-	    baseurl+=$$build_number/artifact/artifacts/$$distro/;           \
-	    $(call install_repo,$$baseurl);                                 \
+	    baseurl+=$$build_number/artifact/artifacts/$$distro/;                                          \
+	    $(call install_repo,$$baseurl)                                                                 \
         done
 endef
 

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -11,9 +11,14 @@ ln -sf /etc/mock/logging.ini "$mock_config_dir/"
 
 cp "$original_cfg_file" "$cfg_file"
 
-if [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
-    echo -e "config_opts['module_enable'] = ['javapackages-tools:201801']" \
-        >> "$cfg_file"
+if [[ $CHROOT_NAME == *epel-8-x86_64 ]]; then
+    cat <<EOF >> "$cfg_file"
+config_opts['module_setup_commands'] = [
+  ('enable', 'javapackages-tools:201801'),
+  ('disable',  'go-toolset')
+]
+EOF
+
 fi
 
 # shellcheck disable=SC2153


### PR DESCRIPTION
This is necessary to keep headers in sync with HPE's libfabric v1.14.0

That patch should be removed once HPE has switched to using v1.15.2 as a base version