### PR TITLE
DAOS-10828 libfabric: add CXI patch separately 

### DIFF
--- a/cxi_provider.patch
+++ b/cxi_provider.patch
@@ -1,0 +1,79 @@
+From 002982d08ccbca86c2adf5ec330fd0fc5691ac4c Mon Sep 17 00:00:00 2001
+From: Steve Welch <welch@hpe.com>
+Date: Thu, 16 Jun 2022 16:10:28 -0500
+Subject: [PATCH] Modify patch to fix backward compatibility issues with 1.14.0
+
+Signed-off-by: Jerome Soumagne <jerome.soumagne@intel.com>
+
+core: Reserve CXI provider constants to avoid conflicts
+
+Reserve address and protocol constants for the CXI provider
+to avoid conflicts in applications that may be using a
+pre-upstream release of the provider with other provider
+definitions.
+
+Signed-off-by: Steve Welch <welch@hpe.com>
+---
+ include/rdma/fabric.h | 2 ++
+ src/common.c          | 4 ++++
+ src/fi_tostr.c        | 2 ++
+ 3 files changed, 8 insertions(+)
+
+diff --git a/include/rdma/fabric.h b/include/rdma/fabric.h
+index 949c496f7..7874a6f42 100644
+--- a/include/rdma/fabric.h
++++ b/include/rdma/fabric.h
+@@ -206,6 +206,7 @@ enum {
+ 	FI_ADDR_IB_UD,		/* uint64_t[4] */
+ 	FI_ADDR_EFA,
+ 	FI_ADDR_PSMX3,		/* uint64_t[4] */
++	FI_ADDR_CXI,
+ 	FI_ADDR_OPX,
+ };
+ 
+@@ -321,6 +322,7 @@ enum {
+ 	FI_PROTO_RDMA_CM_IB_XRC,
+ 	FI_PROTO_EFA,
+ 	FI_PROTO_PSMX3,
++	FI_PROTO_CXI,
+ 	FI_PROTO_RXM_TCP,
+ 	FI_PROTO_OPX,
+ };
+diff --git a/src/common.c b/src/common.c
+index 89fa32ae5..841ae72d9 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -446,6 +446,10 @@ sa_sin6:
+ 	case FI_ADDR_STR:
+ 		size = snprintf(buf, *len, "%s", (const char *) addr);
+ 		break;
++	case FI_ADDR_CXI:
++		size = snprintf(buf, *len, "fi_addr_cxi://0x%08" PRIx32,
++				*(uint32_t *)addr);
++		break;
+ 	default:
+ 		return NULL;
+ 	}
+diff --git a/src/fi_tostr.c b/src/fi_tostr.c
+index 0fd0c3ad8..dfda1e6a4 100644
+--- a/src/fi_tostr.c
++++ b/src/fi_tostr.c
+@@ -123,6 +123,7 @@ static void ofi_tostr_addr_format(char *buf, size_t len, uint32_t addr_format)
+ 	CASEENUMSTRN(FI_ADDR_EFA, len);
+ 	CASEENUMSTRN(FI_ADDR_PSMX3, len);
+ 	CASEENUMSTRN(FI_ADDR_OPX, len);
++	CASEENUMSTRN(FI_ADDR_CXI, len);
+ 	default:
+ 		if (addr_format & FI_PROV_SPECIFIC)
+ 			ofi_strncatf(buf, len, "Provider specific");
+@@ -272,6 +273,7 @@ static void ofi_tostr_protocol(char *buf, size_t len, uint32_t protocol)
+ 	CASEENUMSTRN(FI_PROTO_PSMX3, len);
+ 	CASEENUMSTRN(FI_PROTO_RXM_TCP, len);
+ 	CASEENUMSTRN(FI_PROTO_OPX, len);
++	CASEENUMSTRN(FI_PROTO_CXI, len);
+ 	default:
+ 		if (protocol & FI_PROV_SPECIFIC)
+ 			ofi_strncatf(buf, len, "Provider specific");
+-- 
+2.36.1
+


### PR DESCRIPTION
Add patch separately so that we can reference it by commit