### PR TITLE
DAOS-17056 libfabric: re-enable psm2 provider

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfabric (1.22.0-2) unstable; urgency=medium
+  [ Jerome Soumagne ]
+  * Re-enable psm2 provider for other applications depending on libfabric
+
+ -- Jerome Soumagne <jerome.soumagne@intel.com>  Thu, 06 Feb 2025 11:00:00 -0600
+
 libfabric (1.22.0-1) unstable; urgency=medium
   [ Jerome Soumagne ]
   * Update to 1.22.0

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ Build-Depends: debhelper (>= 10),
                dpkg-dev (>= 1.13.19),
                libibverbs-dev,
                librdmacm-dev,
-               libnuma-dev
+               libnuma-dev,
+               libpsm2-dev
 Standards-Version: 4.1.3
 Homepage: https://ofiwg.github.io/libfabric/
 Vcs-Git: https://salsa.debian.org/hpc-team/libfabric

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ configure_providers = \
 	--enable-verbs \
 	--enable-rxm \
 	--enable-shm \
+	--enable-psm2 \
 	--disable-static \
 	--disable-opx \
 	--disable-usnic \
@@ -25,7 +26,6 @@ configure_providers = \
 	--disable-mrail \
 	--disable-udp \
 	--disable-psm \
-	--disable-psm2 \
 	--disable-psm3 \
 	--disable-gni \
 	--disable-bgq \

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -4,7 +4,7 @@
 
 Name:           libfabric
 Version:        1.22.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 
 # dl_version is version with ~ removed
 %{lua:
@@ -40,6 +40,7 @@ BuildRequires:  numactl-devel
 %endif
 BuildRequires:  fdupes
 BuildRequires:  valgrind-devel
+BuildRequires:  libpsm2-devel
 # required by OPX provider
 BuildRequires:  libuuid-devel
 
@@ -106,6 +107,7 @@ export CXXFLAGS="%{optflags} -fPIC -pie"
             --enable-verbs            \
             --enable-rxm              \
             --enable-shm              \
+            --enable-psm2             \
             --enable-opx              \
             --disable-usnic           \
             --disable-efa             \
@@ -119,7 +121,6 @@ export CXXFLAGS="%{optflags} -fPIC -pie"
             --disable-mrail           \
             --disable-udp             \
             --disable-psm             \
-            --disable-psm2            \
             --disable-psm3            \
             --disable-gni             \
             --disable-bgq
@@ -172,6 +173,9 @@ find %{buildroot} -name '*.la' -exec rm -f {} ';'
 %{_mandir}/man7/*.7*
 
 %changelog
+* Thu Feb 06 2025 Jerome Soumagne <jerome.soumagne@intel.com> - 1.22.0-2
+- Re-enable psm2 provider for other applications depending on libfabric
+
 * Fri Oct 25 2024 Jerome Soumagne <jerome.soumagne@intel.com> - 1.22.0-1
 - Update to 1.22.0
 - Drop prov/verbs patch merged upstream

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -91,6 +91,14 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 15.5
 SED_EXPR        := 1p
 endif
+ifeq ($(CHROOT_NAME),opensuse-leap-15.6-x86_64)
+VERSION_ID      := 15.6
+DISTRO_ID       := sl15.6
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.6
+SED_EXPR        := 1p
+endif
 endif
 ifeq ($(ID),centos)
 ID = el


### PR DESCRIPTION
Some applications may still depend on psm2 provider